### PR TITLE
On Linux, each compile flag should be quoted separately, otherwise it…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library( npy STATIC ${SOURCES} )
 add_library( npy::npy ALIAS npy )
 
 if ( CMAKE_COMPILER_IS_GNUCC )
-  target_compile_options(npy PRIVATE "-Wall -Wextra")
+  target_compile_options(npy PRIVATE "-Wall" "-Wextra")
 elseif( MSVC )
   target_compile_options(npy PRIVATE "/W4")
 endif()


### PR DESCRIPTION
…'s interpreted as a single option.